### PR TITLE
🥅 adding check on PostType name

### DIFF
--- a/src/PostType/Exceptions/PostTypeNameEmptyException.php
+++ b/src/PostType/Exceptions/PostTypeNameEmptyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PostTypeHandler\PostType\Exceptions;
+
+class PostTypeNameEmptyException extends \Exception {
+
+	public function __construct( $message = '', $code = 0, \Throwable $previous = null ) {
+		parent::__construct( $message, $code, $previous );
+	}
+}

--- a/src/PostType/Exceptions/PostTypeNameLimitException.php
+++ b/src/PostType/Exceptions/PostTypeNameLimitException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PostTypeHandler\PostType\Exceptions;
+
+class PostTypeNameLimitException extends \Exception {
+
+	public function __construct( $message = '', $code = 0, \Throwable $previous = null ) {
+		parent::__construct( $message, $code, $previous );
+	}
+}


### PR DESCRIPTION
Adding exceptions when a PostType name is empty or exceed 20 characters according to WordPress documentation.

Ref: #1