### PR TITLE
🥅 adding check on Taxonomy slug

### DIFF
--- a/src/Taxonomy/Exceptions/TaxonomyNameEmptyException.php
+++ b/src/Taxonomy/Exceptions/TaxonomyNameEmptyException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PostTypeHandler\Taxonomy\Exceptions;
+
+class TaxonomyNameEmptyException extends \Exception {
+	public function __construct( $message = '', $code = 0, \Throwable $previous = null ) {
+		parent::__construct( $message, $code, $previous );
+	}
+}

--- a/src/Taxonomy/Exceptions/TaxonomyNameLimitException.php
+++ b/src/Taxonomy/Exceptions/TaxonomyNameLimitException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PostTypeHandler\Taxonomy\Exceptions;
+
+class TaxonomyNameLimitException extends \Exception {
+	public function __construct( $message = '', $code = 0, \Throwable $previous = null ) {
+		parent::__construct( $message, $code, $previous );
+	}
+}

--- a/src/Taxonomy/TaxonomyRegisterer.php
+++ b/src/Taxonomy/TaxonomyRegisterer.php
@@ -3,8 +3,11 @@
 namespace PostTypeHandler\Taxonomy;
 
 use PostTypeHandler\Taxonomy;
+use PostTypeHandler\Taxonomy\Exceptions\TaxonomyNameEmptyException;
+use PostTypeHandler\Taxonomy\Exceptions\TaxonomyNameLimitException;
 
 final class TaxonomyRegisterer {
+	private const KEY_MAX_LENGTH = 32;
 
 	private Taxonomy $taxonomy;
 
@@ -15,13 +18,15 @@ final class TaxonomyRegisterer {
 	/**
 	 * Register the taxonomy only if it doesn't already exist.
 	 * If the taxonomy is registered, it will update its options.
-	 * 
+	 *
 	 * @see https://developer.wordpress.org/reference/functions/register_taxonomy/
 	 *
 	 * @return WP_Taxonomy|WP_Error The registered taxonomy object on success, WP_Error object on failure
+	 * @throws TaxonomyNameLimitException
+	 * @throws TaxonomyNameEmptyException
 	 */
 	public function register_taxonomy() {
-		if ( ! taxonomy_exists( $this->taxonomy->get_slug() ) ) {
+		if ( ! taxonomy_exists( $this->taxonomy->get_slug() ) && $this->is_valid_slug( $this->taxonomy->get_slug() ) ) {
 			$labels            = $this->taxonomy->make_labels();
 			$options           = $this->taxonomy->make_options();
 			$options['labels'] = $labels;
@@ -30,5 +35,29 @@ final class TaxonomyRegisterer {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if the taxonomy slug is valid (not empty and not exceed 32 characters).
+	 *
+	 * @param string $slug
+	 *
+	 * @return bool
+	 * @throws TaxonomyNameLimitException
+	 * @throws TaxonomyNameEmptyException
+	 */
+	private function is_valid_slug( string $slug ): bool {
+		if ( empty( $slug ) ) {
+			throw new TaxonomyNameEmptyException( 'The taxonomy slug cannot be empty.' );
+		}
+
+		if ( strlen( $slug ) > self::KEY_MAX_LENGTH ) {
+			throw new TaxonomyNameLimitException( sprintf(
+				'The taxonomy slug must not exceed %d characters.',
+				self::KEY_MAX_LENGTH
+			) );
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Adding check on Taxonomy slug, when a slug is empty or exceed 32 characters.

Ref: #4