### PR TITLE
Check slug conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,13 @@ $post_type_handler->set_taxonomy_filters( [
 
 ## Hooks
 
-| Hook type | Hook name                         | Params         | Description                          |
-| --------- | --------------------------------- | -------------- | ------------------------------------ |
-| Filter    | gt_post_type_{$post_type}_labels  | array $labels  | Custom the labels for the post type  |
-| Filter    | gt_post_type_{$post_type}_options | array $options | Custom the options for the post type |
-| Filter    | gt_taxonomy_{$post_type}_labels   | array $labels  | Custom the labels for the taxonomy   |
-| Filter    | gt_taxonomy_{$post_type}_options  | array $options | Custom the options for the taxonomy  |
+| Hook type | Hook name                                     | Params         | Description                                  |
+| --------- | --------------------------------------------- | -------------- | -------------------------------------------- |
+| Filter    | gt_post_type_{$post_type}_labels              | array $labels  | Custom the labels for the post type          |
+| Filter    | gt_post_type_{$post_type}_options             | array $options | Custom the options for the post type         |
+| Filter    | gt_post_type_{$post_type}_check_slug_conflict | boolean $check | Check for slug conflicts. Requires DB query. |
+| Filter    | gt_taxonomy_{$post_type}_labels               | array $labels  | Custom the labels for the taxonomy           |
+| Filter    | gt_taxonomy_{$post_type}_options              | array $options | Custom the options for the taxonomy          |
 
 
 ## TODOS

--- a/src/PostType/Exceptions/PostTypeSlugConflictException.php
+++ b/src/PostType/Exceptions/PostTypeSlugConflictException.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Define PostTypeSlugConflictException exception.
+ */
+
+namespace PostTypeHandler\PostType\Exceptions;
+
+/**
+ * Exception thrown when there is a conflict with an existing slug.
+ */
+class PostTypeSlugConflictException extends \Exception {
+
+	/**
+	 * Exception error code.
+	 *
+	 * @var integer Error code.
+	 */
+	const CODE = 9993;
+
+	/**
+	 * Construct exception object.
+	 *
+	 * @param string     $message Exception message.
+	 * @param \Throwable $previous Previous exception.
+	 * @return PostTypeSlugConflictException The exception object.
+	 */
+	public function __construct( $message = '', \Throwable $previous = null ) {
+		return parent::__construct( $message, self::CODE, $previous );
+	}
+}

--- a/src/PostType/PostTypeRegisterer.php
+++ b/src/PostType/PostTypeRegisterer.php
@@ -5,6 +5,7 @@ namespace PostTypeHandler\PostType;
 use PostTypeHandler\PostType;
 use PostTypeHandler\PostType\Exceptions\PostTypeNameEmptyException;
 use PostTypeHandler\PostType\Exceptions\PostTypeNameLimitException;
+use PostTypeHandler\PostType\Exceptions\PostTypeSlugConflictException;
 
 final class PostTypeRegisterer {
 	private const KEY_MAX_LENGTH = 20;

--- a/src/PostType/PostTypeRegisterer.php
+++ b/src/PostType/PostTypeRegisterer.php
@@ -85,7 +85,7 @@ final class PostTypeRegisterer {
 
 		if ( strlen( $slug ) > self::KEY_MAX_LENGTH ) {
 			throw new PostTypeNameLimitException( sprintf(
-				'The post type name must no exceed $d characters.',
+				'The post type name must no exceed %d characters.',
 				self::KEY_MAX_LENGTH
 			) );
 		}
@@ -97,14 +97,18 @@ final class PostTypeRegisterer {
 		 *
 		 * @param boolean $check_slug_conflict Whether to check for slug conflicts.
 		 */
-		$check_slug_conflict = (bool) apply_filters( 'gt_post_type_' . $this->post_type->get_slug() . '_check_slug_conflict', true );
+		$wp_debug            = defined( 'WP_DEBUG' ) ? WP_DEBUG : false;
+		$check_slug_conflict = (bool) apply_filters( 'gt_post_type_' . $this->post_type->get_slug() . '_check_slug_conflict', $wp_debug );
+		
 		if ( $check_slug_conflict ) {
 			// Replicate slug check logic from the wp-includes/post.php wp_unique_post_slug() function.
 			global $wpdb;
+			
 			$check_sql       = "SELECT post_name FROM $wpdb->posts WHERE post_name = %s LIMIT 1";
 			$post_name_query = $wpdb->get_var( $wpdb->prepare( $check_sql, $this->post_type->get_slug() ) );
+
 			if ( $post_name_query ) {
-				throw new PostTypeSlugConflictException( 'Post type conflicts with existing post_name slug.' );
+				throw new PostTypeSlugConflictException( 'Post type "' . $this->post_type->get_slug() . '" slug conflicts with existing post_name slug.' );
 			}
 		}
 

--- a/src/PostType/PostTypeRegisterer.php
+++ b/src/PostType/PostTypeRegisterer.php
@@ -67,13 +67,15 @@ final class PostTypeRegisterer {
 
 
 	/**
-	 * Check if the Post Type slug is valid (not empty and not exceed KEY_MAX_LENGTH characters).
+	 * Check if the Post Type slug is valid (not empty, not exceed KEY_MAX_LENGTH characters,
+	 * not conflict with existing slug).
 	 *
 	 * @param string $slug
 	 *
 	 * @return bool
 	 * @throws PostTypeNameLimitException
 	 * @throws PostTypeNameEmptyException
+	 * @throws PostTypeSlugConflictException
 	 */
 	private function is_valid_slug( string $slug ): bool {
 		if ( empty( $slug ) ) {
@@ -85,6 +87,24 @@ final class PostTypeRegisterer {
 				'The post type name must no exceed $d characters.',
 				self::KEY_MAX_LENGTH
 			) );
+		}
+
+		/**
+		 * Filters whether to check for slug conflicts with existing Page, Post,
+		 * and Custom Post Type records. Checking requires a DB query, which
+		 * may be avoided.
+		 *
+		 * @param boolean $check_slug_conflict Whether to check for slug conflicts.
+		 */
+		$check_slug_conflict = (bool) apply_filters( 'gt_post_type_' . $this->post_type->get_slug() . '_check_slug_conflict', true );
+		if ( $check_slug_conflict ) {
+			// Replicate slug check logic from the wp-includes/post.php wp_unique_post_slug() function.
+			global $wpdb;
+			$check_sql       = "SELECT post_name FROM $wpdb->posts WHERE post_name = %s LIMIT 1";
+			$post_name_query = $wpdb->get_var( $wpdb->prepare( $check_sql, $this->post_type->get_slug() ) );
+			if ( $post_name_query ) {
+				throw new PostTypeSlugConflictException( 'Post type conflicts with existing post_name slug.' );
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Implements issue #2.

Checks for existing post_name conflicts with a new Post Type during registration alongside the other validations. Implements similar PHP Exception subclasses to existing validation.

Whether to check is filtered due to the DB call's performance impact, defaulting to true. Filter is documented in README file.

Possible change: Set the check to default to the current WP_DEBUG setting rather than true. Alternately, default to false to not check.

Testing snippet code. Change the returned filter value.

```
$slug_query = new WP_Query(
	[
		'name'                   => 'example',
		'post_type'              => 'any',
		'fields'                 => 'ids',
		'cache_results'          => 'false',
		'update_post_meta_cache' => 'false',
		'update_post_term_cache' => 'false',
		'posts_per_page'         => 1,
	]
);
if ( $slug_query->post_count < 1 ) {
	wp_insert_post(
		[
			'post_title'  => 'Example for slug conflict testing.',
			'post_name'   => 'example',
			'post_type'   => 'page',
			'post_status' => 'publish',
		]
	);
}
add_filter(
	'gt_post_type_example_check_slug_conflict',
	function() {
		return true;
	}
);
$posts = new PostType( 'Example' );
$posts->register();
```